### PR TITLE
minor change in cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,10 @@ project (libnpa)
 find_package(Boost REQUIRED COMPONENTS locale)
 
 set(CMAKE_BUILD_TYPE Debug)
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/include)
 add_definitions(-std=c++11)
 
-file(
-GLOB_RECURSE
-LIBNPA_SRC
-${CMAKE_SOURCE_DIR}/src/*
-)
+aux_source_directory(${PROJECT_SOURCE_DIR}/src/ LIBNPA_SRC)
 
 add_library(npa SHARED ${LIBNPA_SRC})
 set_target_properties(npa PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
Got rid of GLOB_RECURSE macro and used aux_source_directory.
It has some benefits, such as painless including as a submodule in other projects :)
