### PR TITLE
add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,6 @@ aux_source_directory(${PROJECT_SOURCE_DIR}/src/ LIBNPA_SRC)
 add_library(npa SHARED ${LIBNPA_SRC})
 target_link_libraries(npa ${Boost_LIBRARIES})
 set_target_properties(npa PROPERTIES LINKER_LANGUAGE CXX)
+
+# install target
+install(TARGETS npa DESTINATION lib)


### PR DESCRIPTION
Adds an install target so i can pass a prefix dir to cmake and install the library to it later.

For example:

```
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_INSTALL_PREFIX=/usr
$ make
$ make install
```

done
