### PR TITLE
Fix flex function prototype for flex > 2.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 
 flex_target(lexer ${CMAKE_SOURCE_DIR}/src/lexer.l ${CMAKE_SOURCE_DIR}/src/lexer.cpp)
 bison_target(parser ${CMAKE_SOURCE_DIR}/src/parser.y ${CMAKE_SOURCE_DIR}/src/parser.cpp)
+add_flex_bison_dependency(lexer parser)
 
 add_library(npa SHARED
     src/inpafile.cpp
@@ -73,8 +74,8 @@ add_library(npa SHARED
     src/npakeys.cpp
     src/buffer.cpp
     src/nsscompiler.cpp
-    src/parser.cpp
-    src/lexer.cpp
+    ${BISON_parser_OUTPUTS}
+    ${FLEX_lexer_OUTPUTS}
     src/nsbconstants.cpp
 )
 target_link_libraries(npa ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/include/flex.hpp
+++ b/include/flex.hpp
@@ -3,9 +3,8 @@
 
 typedef struct yy_buffer_state* YY_BUFFER_STATE;
 extern int yyparse();
-#if ((FLEX_VERSION_MAJOR) > 2 || \
-    ((FLEX_VERSION_MAJOR == 2 && FLEX_VERSION_MINOR > 5) || \
-    ((FLEX_VERSION_MAJOR == 2 && FLEX_VERSION_MINOR == 5 && FLEX_VERSION_PATCH > 35))))
+#if ((FLEX_VERSION_MAJOR == 2 && FLEX_VERSION_MINOR == 6 && FLEX_VERSION_PATCH == 0) || \
+    (FLEX_VERSION_MAJOR == 2 && FLEX_VERSION_MINOR == 5 && FLEX_VERSION_PATCH > 35))
 extern YY_BUFFER_STATE yy_scan_bytes(const char* bytes, size_t len);
 #else
 extern YY_BUFFER_STATE yy_scan_bytes(const char* bytes, int len);


### PR DESCRIPTION
(fixes FGRE/steins-gate-new#1)

Apparently they have changed the prototype back to how it was before 2.5.35...
- 2008, introducing the change in 2.5.36: https://github.com/westes/flex/commit/9ba3187a537d
- relevant bug report: https://sourceforge.net/p/flex/bugs/184/
- 2016, reverting this for 2.6.1: https://github.com/westes/flex/commit/7a7c3dfe1bcb